### PR TITLE
Add package cache update debian

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for docker
+pkg_sync_period: '2 days ago'
+pkg_sync_period_mirror: '7 days ago'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,3 +12,25 @@
 - name: configure gentoo
   include_tasks: configure-gentoo.yml
   when: ansible_os_family == 'Gentoo'
+
+- name: Get non mirror period timestamp
+  command: date -d "{{ pkg_sync_period }}" +%s
+  register: pkg_timestamp
+  changed_when: False
+  failed_when: pkg_timestamp.rc != 0
+  when:
+    - "'pkg_mirror' not in group_names"
+    - not ansible_check_mode
+
+- name: Get mirror period timestamp
+  command: date -d '{{ pkg_sync_period_mirror }}' +%s
+  register: pkg_timestamp_mirror
+  changed_when: False
+  failed_when: pkg_timestamp_mirror.rc != 0
+  when:
+    - "'pkg_mirror' in group_names"
+    - not ansible_check_mode
+
+- name: update cache Debian
+  include_tasks: package-update-debian.yml
+  when: ansible_os_family == 'Debian'

--- a/tasks/package-update-debian.yml
+++ b/tasks/package-update-debian.yml
@@ -1,0 +1,51 @@
+---
+- name: Get last sync date
+  command: stat -c %Y /var/lib/apt/lists
+  register: apt_update_date
+  changed_when: False
+  failed_when: apt_update_date.rc != 0
+  when:
+    - ansible_os_family == 'Debian'
+    - not ansible_check_mode
+
+- name: Date debug Debian non-mirror
+  debug:
+    msg:
+      - "To update apt_update_date should be older (<) than pkg_timestamp"
+      - "                     |  timestamp   | date"
+      - "pkg_timestamp        |  {{ pkg_timestamp.stdout }}  | {{ pkg_sync_period }}"
+      - "apt_update_date      |  {{ apt_update_date.stdout }} "
+  when:
+    - ansible_os_family == 'Debian'
+    - "'pkg_mirror' not in group_names"
+    - not ansible_check_mode
+
+- name: Date debug Debian mirror
+  debug:
+    msg:
+      - "To update apt_update_date_ should be older (<) than pkg_timestamp_mirror"
+      - "                     |  timestamp   | date"
+      - "pkg_timestamp_mirror |  {{ pkg_timestamp.stdout }}  | {{ pkg_sync_period }}"
+      - "apt_update_date      |  {{ apt_update_date.stdout }} "
+  when:
+    - ansible_os_family == 'Debian'
+    - "'pkg_mirror' in group_names"
+    - not ansible_check_mode
+
+- name: Apt sync non mirror
+  command: apt update
+  when:
+    - ansible_os_family == 'Debian'
+    - pkg_timestamp.stdout is defined
+    - apt_update_date.stdout is defined and apt_update_date.stdout | int() <= pkg_timestamp.stdout | int()
+    - "'pkg_mirror' not in group_names"
+    - not ansible_check_mode
+
+- name: Apt sync mirror
+  command: apt update
+  when:
+    - ansible_os_family == 'Debian'
+    - pkg_timestamp_mirror.stdout is defined
+    - (apt_update_date.stdout is defined and apt_update_date.stdout | int() <= pkg_timestamp_mirror.stdout | int())
+    - "'pkg_mirror' in group_names"
+    - not ansible_check_mode


### PR DESCRIPTION
This commit add the following:
  * We define a pkg_sync_period and pkg_sync_period_mirror
  * We use that value to only refresh package cache after a period